### PR TITLE
update bond names, replace avax and time with one and psi in slices

### DIFF
--- a/src/helpers/bond/index.ts
+++ b/src/helpers/bond/index.ts
@@ -24,10 +24,10 @@ export const mim = new StableBond({
     },
 });
 
-export const wavax = new CustomBond({
-    name: "wavax",
-    displayName: "wAVAX",
-    bondToken: "AVAX",
+export const wone = new CustomBond({
+    name: "wone",
+    displayName: "wONE",
+    bondToken: "ONE",
     bondIconSvg: AvaxIcon,
     bondContractABI: WavaxBondContract,
     reserveContractAbi: StableReserveContract,
@@ -39,9 +39,9 @@ export const wavax = new CustomBond({
     },
 });
 
-export const mimTime = new LPBond({
-    name: "mim_time_lp",
-    displayName: "TIME-MIM LP",
+export const mimPsi = new LPBond({
+    name: "mim_psi_lp",
+    displayName: "PSI-MIM LP",
     bondToken: "MIM",
     bondIconSvg: MimTimeIcon,
     bondContractABI: LpBondContract,
@@ -55,10 +55,10 @@ export const mimTime = new LPBond({
     lpUrl: "https://www.traderjoexyz.com/#/pool/0x130966628846BFd36ff31a822705796e8cb8C18D/0xb54f16fB19478766A268F172C9480f8da1a7c9C3",
 });
 
-export const avaxTime = new CustomLPBond({
-    name: "avax_time_lp",
-    displayName: "TIME-AVAX LP",
-    bondToken: "AVAX",
+export const onePsi = new CustomLPBond({
+    name: "one_psi_lp",
+    displayName: "PSI-ONE LP",
+    bondToken: "ONE",
     bondIconSvg: AvaxTimeIcon,
     bondContractABI: LpBondContract,
     reserveContractAbi: LpReserveContract,
@@ -71,4 +71,4 @@ export const avaxTime = new CustomLPBond({
     lpUrl: "https://www.traderjoexyz.com/#/pool/AVAX/0xb54f16fB19478766A268F172C9480f8da1a7c9C3",
 });
 
-export default [mim, wavax, mimTime, avaxTime];
+export default [mim, wone, mimPsi, onePsi];

--- a/src/helpers/get-market-price.ts
+++ b/src/helpers/get-market-price.ts
@@ -1,11 +1,11 @@
 import { ethers } from "ethers";
 import { LpReserveContract } from "../abi";
-import { mimTime } from "../helpers/bond";
+import { mimPsi } from "../helpers/bond";
 import { Networks } from "../constants/blockchain";
 
 export async function getMarketPrice(networkID: Networks, provider: ethers.Signer | ethers.providers.Provider): Promise<number> {
-    const mimTimeAddress = mimTime.getAddressForReserve(networkID);
-    const pairContract = new ethers.Contract(mimTimeAddress, LpReserveContract, provider);
+    const mimPsiAddress = mimPsi.getAddressForReserve(networkID);
+    const pairContract = new ethers.Contract(mimPsiAddress, LpReserveContract, provider);
     const reserves = await pairContract.getReserves();
     const marketPrice = reserves[0] / reserves[1];
     return marketPrice;

--- a/src/helpers/token-price.ts
+++ b/src/helpers/token-price.ts
@@ -3,12 +3,11 @@ import axios from "axios";
 const cache: { [key: string]: number } = {};
 
 export const loadTokenPrices = async () => {
-    const url = "https://api.coingecko.com/api/v3/simple/price?ids=harmony,olympus,magic-internet-money&vs_currencies=usd";
+    const url = "https://api.coingecko.com/api/v3/simple/price?ids=harmony,magic-internet-money&vs_currencies=usd";
     const { data } = await axios.get(url);
 
     cache["ONE"] = data["harmony"].usd;
     cache["MIM"] = data["magic-internet-money"].usd;
-    cache["OHM"] = data["olympus"].usd;
 };
 
 export const getTokenPrice = (symbol: string): number => {

--- a/src/store/slices/bond-slice.ts
+++ b/src/store/slices/bond-slice.ts
@@ -10,7 +10,7 @@ import { Bond } from "../../helpers/bond/bond";
 import { Networks } from "../../constants/blockchain";
 import { getBondCalculator } from "../../helpers/bond-calculator";
 import { RootState } from "../store";
-import { avaxTime, wavax } from "../../helpers/bond";
+import { onePsi, wone } from "../../helpers/bond";
 import { error, warning, success, info } from "../slices/messages-slice";
 import { messages } from "../../constants/messages";
 import { getGasPrice } from "../../helpers/get-gas-price";
@@ -125,7 +125,7 @@ export const calcBondDetails = createAsyncThunk("bonding/calcBondDetails", async
     try {
         bondPrice = await bondContract.bondPriceInUSD();
 
-        if (bond.name === avaxTime.name) {
+        if (bond.name === onePsi.name) {
             const onePrice = getTokenPrice("ONE");
             bondPrice = bondPrice * onePrice;
         }
@@ -169,11 +169,11 @@ export const calcBondDetails = createAsyncThunk("bonding/calcBondDetails", async
         purchased = await bondCalcContract.valuation(assetAddress, purchased);
         purchased = (markdown / Math.pow(10, 18)) * (purchased / Math.pow(10, 9));
 
-        if (bond.name === avaxTime.name) {
+        if (bond.name === onePsi.name) {
             const onePrice = getTokenPrice("ONE");
             purchased = purchased * onePrice;
         }
-    } else if (bond.name === wavax.name) {
+    } else if (bond.name === wone.name) {
         purchased = purchased / Math.pow(10, 18);
         const onePrice = getTokenPrice("ONE");
         purchased = purchased * onePrice;

--- a/src/store/slices/stake-thunk.ts
+++ b/src/store/slices/stake-thunk.ts
@@ -25,23 +25,24 @@ export const changeApproval = createAsyncThunk("stake/changeApproval", async ({ 
     const addresses = getAddresses(networkID);
 
     const signer = provider.getSigner();
-    const timeContract = new ethers.Contract(addresses.TIME_ADDRESS, TimeTokenContract, signer);
-    const memoContract = new ethers.Contract(addresses.MEMO_ADDRESS, MemoTokenContract, signer);
+    // TODO: update addresses to PSI and sPSI
+    const psiContract = new ethers.Contract(addresses.TIME_ADDRESS, TimeTokenContract, signer);
+    const sPsiContract = new ethers.Contract(addresses.MEMO_ADDRESS, MemoTokenContract, signer);
 
     let approveTx;
     try {
         const gasPrice = await getGasPrice(provider);
 
-        if (token === "time") {
-            approveTx = await timeContract.approve(addresses.STAKING_HELPER_ADDRESS, ethers.constants.MaxUint256, { gasPrice });
+        if (token === "psi") {
+            approveTx = await psiContract.approve(addresses.STAKING_HELPER_ADDRESS, ethers.constants.MaxUint256, { gasPrice });
         }
 
-        if (token === "memo") {
-            approveTx = await memoContract.approve(addresses.STAKING_ADDRESS, ethers.constants.MaxUint256, { gasPrice });
+        if (token === "spsi") {
+            approveTx = await sPsiContract.approve(addresses.STAKING_ADDRESS, ethers.constants.MaxUint256, { gasPrice });
         }
 
-        const text = "Approve " + (token === "time" ? "Staking" : "Unstaking");
-        const pendingTxnType = token === "time" ? "approve_staking" : "approve_unstaking";
+        const text = "Approve " + (token === "psi" ? "Staking" : "Unstaking");
+        const pendingTxnType = token === "psi" ? "approve_staking" : "approve_unstaking";
 
         dispatch(fetchPendingTxns({ txnHash: approveTx.hash, text, type: pendingTxnType }));
         dispatch(success({ text: messages.tx_successfully_send }));
@@ -55,8 +56,8 @@ export const changeApproval = createAsyncThunk("stake/changeApproval", async ({ 
         }
     }
 
-    const stakeAllowance = await timeContract.allowance(address, addresses.STAKING_HELPER_ADDRESS);
-    const unstakeAllowance = await memoContract.allowance(address, addresses.STAKING_ADDRESS);
+    const stakeAllowance = await psiContract.allowance(address, addresses.STAKING_HELPER_ADDRESS);
+    const unstakeAllowance = await sPsiContract.allowance(address, addresses.STAKING_ADDRESS);
 
     return dispatch(
         fetchAccountSuccess({

--- a/src/views/Bond/BondPurchase.tsx
+++ b/src/views/Bond/BondPurchase.tsx
@@ -125,11 +125,11 @@ function BondPurchase({ bond, slippage, recipientAddress }: IBondPurchaseProps) 
     return (
         <Box display="flex" flexDirection="column">
             <Box display="flex" justifyContent="space-around" flexWrap="wrap">
-                {bond.name === "wavax" && (
+                {bond.name === "wone" && (
                     <FormControl className="ohm-input" variant="outlined" color="primary" fullWidth>
-                        <div className="avax-checkbox">
+                        <div className="one-checkbox">
                             <input type="checkbox" checked={useAvax} onClick={() => setUseAvax(!useAvax)} />
-                            <p>Use AVAX</p>
+                            <p>Use ONE</p>
                         </div>
                     </FormControl>
                 )}

--- a/src/views/Bond/bond.scss
+++ b/src/views/Bond/bond.scss
@@ -103,7 +103,7 @@
     max-width: 408px;
     margin: 5px;
 
-    .avax-checkbox {
+    .one-checkbox {
       display: flex;
       flex-direction: row;
       align-items: center;

--- a/src/views/Bond/index.tsx
+++ b/src/views/Bond/index.tsx
@@ -68,11 +68,11 @@ function Bond({ bond }: IBondProps) {
                                 <div className="bond-price-data">
                                     <p className="bond-price-data-title">Mint Price</p>
                                     <p className="bond-price-data-value">
-                                        {isBondLoading ? <Skeleton /> : bond.isLP || bond.name === "wavax" ? `$${trim(bond.bondPrice, 2)}` : `${trim(bond.bondPrice, 2)} MIM`}
+                                        {isBondLoading ? <Skeleton /> : bond.isLP || bond.name === "wone" ? `$${trim(bond.bondPrice, 2)}` : `${trim(bond.bondPrice, 2)} MIM`}
                                     </p>
                                 </div>
                                 <div className="bond-price-data">
-                                    <p className="bond-price-data-title">TIME Price</p>
+                                    <p className="bond-price-data-title">PSI Price</p>
                                     <p className="bond-price-data-value">{isBondLoading ? <Skeleton /> : `$${trim(bond.marketPrice, 2)}`}</p>
                                 </div>
                             </Box>


### PR DESCRIPTION
- update bond variable and display names
- update variable naming in slices to use psi/sPsi/one instead of time/memo/avax
- reflect bond name changes in frontend rendering logic
- remove OHM initial treasury balance calculation

https://linear.app/tridentdao/issue/TRI-69/update-slices