### PR TITLE
Fixes old link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Trident Frontend](https://tridentdao.finance/)
+# [Trident Frontend](https://trident.game/)
 This is the front-end repo for Trident. 
 
 ##  🔧 Setting up Local Development


### PR DESCRIPTION
I noticed the link in the heading was pointing to what I'm guessing is an old URL that was missing an SSL cert, so I updated it to point to `https://trident.game/`.